### PR TITLE
modify converter to support the current version of KothicJS

### DIFF
--- a/scripts/mapcss_converter.py
+++ b/scripts/mapcss_converter.py
@@ -342,7 +342,7 @@ if __name__ == "__main__":
     mapcss_js = mapcss.as_js()
     subparts_var = ", ".join(map(lambda subpart: "s_%s = {}" % subpart, subparts))
     subparts_var = "        var %s;" % subparts_var
-    subparts_fill = "\n".join(map(lambda subpart: "        if (!K.Utils.isStyleUseful(s_%s)) {\n            style['%s'] = {};\nfor (var attrname in s_everything) { style['%s'][attrname] = s_everything[attrname]; }\nfor (var attrname in s_%s) { style['%s'][attrname] = s_%s[attrname]; }\n        }" % (subpart, subpart, subpart, subpart, subpart, subpart), subparts))
+    subparts_fill = "\n".join(map(lambda subpart: "        if (Object.keys(s_%s).length) {\n            style['%s'] = s_%s;\n        }" % (subpart, subpart, subpart), subparts))
     js = """
 (function (MapCSS) {
     'use strict';


### PR DESCRIPTION
The K.Utils.isStyleUseful syntax is no longer valid for KothicJS. I modified the converter script to play well with kothic-js master.
